### PR TITLE
Update Interfaces.sol to include ADDRESSES_PROVIDER() and LENDING_POOL()

### DIFF
--- a/V2/Flash Loan - Batch/Interfaces.sol
+++ b/V2/Flash Loan - Batch/Interfaces.sol
@@ -90,6 +90,10 @@ interface IFlashLoanReceiver {
     address initiator,
     bytes calldata params
   ) external returns (bool);
+  
+  function ADDRESSES_PROVIDER() external view returns (ILendingPoolAddressesProvider);
+
+  function LENDING_POOL() external view returns (ILendingPool);
 }
 
 /**


### PR DESCRIPTION
Compilation fails due to:

```
contracts/FlashLoanReceiverBase.sol:11:50: TypeError: Public state variable has override specified but does not override anything.
  ILendingPoolAddressesProvider public immutable override ADDRESSES_PROVIDER;
                                                 ^------^

contracts/FlashLoanReceiverBase.sol:12:33: TypeError: Public state variable has override specified but does not override anything.
  ILendingPool public immutable override LENDING_POOL;
                                ^------^
```

Interface needs to be updated to include ADDRESSES_PROVIDER() and LENDING_POOL()
